### PR TITLE
Incorrect number of written bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 The `hid` package is a cross platform library for accessing and communicating with USB Human Interface
 Devices (HID). It is an alternative package to [`gousb`](https://github.com/karalabe/gousb) for use
-cases where devices support this ligher mode of operation (e.g. input devices, hardware crypto wallets).
+cases where devices support this lighter mode of operation (e.g. input devices, hardware crypto wallets).
 
 The package wraps [`hidapi`](https://github.com/signal11/hidapi) for accessing OS specific USB HID APIs
 directly instead of using low level USB constructs, which might have permission issues on some platforms.

--- a/hid_enabled.go
+++ b/hid_enabled.go
@@ -19,7 +19,7 @@ package hid
 #cgo windows LDFLAGS: -lsetupapi
 
 #ifdef OS_LINUX
-	#include <sys/poll.h>
+	#include <poll.h>
 	#include "os/threads_posix.c"
 	#include "os/poll_posix.c"
 

--- a/hid_enabled.go
+++ b/hid_enabled.go
@@ -188,6 +188,13 @@ func (dev *Device) Write(b []byte) (int, error) {
 		failure, _ := wcharTToString(message)
 		return 0, errors.New("hidapi: " + failure)
 	}
+
+	if runtime.GOOS == "windows" {
+		// Do not consider the prepended byte when returning number of written bytes
+		// otherwise this can lead to confusion in other layers
+		written -= 1
+	}
+
 	return written, nil
 }
 

--- a/hidapi/mac/hid.c
+++ b/hidapi/mac/hid.c
@@ -690,7 +690,7 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 		return NULL;
 
 	/* Get the IORegistry entry for the given path */
-	entry = IORegistryEntryFromPath(kIOMasterPortDefault, path);
+	entry = IORegistryEntryFromPath(kIOMainPortDefault, path);
 	if (entry == MACH_PORT_NULL) {
 		/* Path wasn't valid (maybe device was removed?) */
 		goto return_error;

--- a/hidapi/mac/hid.c
+++ b/hidapi/mac/hid.c
@@ -690,7 +690,7 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 		return NULL;
 
 	/* Get the IORegistry entry for the given path */
-	entry = IORegistryEntryFromPath(kIOMainPortDefault, path);
+	entry = IORegistryEntryFromPath(MACH_PORT_NULL, path);
 	if (entry == MACH_PORT_NULL) {
 		/* Path wasn't valid (maybe device was removed?) */
 		goto return_error;

--- a/hidapi/mac/hid.c
+++ b/hidapi/mac/hid.c
@@ -303,7 +303,11 @@ static io_service_t hidapi_IOHIDDeviceGetService(IOHIDDeviceRef device)
 	 * and the fallback method will be used.
 	 */
 	if (iokit_framework == NULL) {
-		iokit_framework = dlopen("/System/Library/IOKit.framework/IOKit", RTLD_LAZY);
+		iokit_framework = dlopen("/System/Library/Frameworks/IOKit.framework/IOKit", RTLD_LAZY);
+
+		if (iokit_framework == NULL) {
+			iokit_framework = dlopen("/System/Library/IOKit.framework/IOKit", RTLD_LAZY);
+		}
 
 		if (iokit_framework != NULL)
 			dynamic_IOHIDDeviceGetService = dlsym(iokit_framework, "IOHIDDeviceGetService");

--- a/hidapi/windows/hid.c
+++ b/hidapi/windows/hid.c
@@ -425,14 +425,17 @@ struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate(unsigned shor
 			/* Fill out the record */
 			cur_dev->next = NULL;
 			str = device_interface_detail_data->DevicePath;
+            cur_dev->path = NULL;
 			if (str) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 				len = strlen(str);
-				cur_dev->path = (char*) calloc(len+1, sizeof(char));
-				strncpy(cur_dev->path, str, len+1);
-				cur_dev->path[len] = '\0';
+				len = min(len, 4096);  // Do not accept device paths over 4096 bytes to avoid possible overflows
+                cur_dev->path = (char*) calloc(len+1, sizeof(char));
+                strncpy(cur_dev->path, str, len+1);
+                cur_dev->path[len] = '\0';
+#pragma GCC diagnostic pop
 			}
-			else
-				cur_dev->path = NULL;
 
 			/* Serial Number */
 			res = HidD_GetSerialNumberString(write_handle, wstr, sizeof(wstr));

--- a/libusb/libusb/os/darwin_usb.c
+++ b/libusb/libusb/os/darwin_usb.c
@@ -235,7 +235,7 @@ static int usb_setup_device_iterator (io_iterator_t *deviceIterator, UInt32 loca
     /* else we can still proceed as long as the caller accounts for the possibility of other devices in the iterator */
   }
 
-  return IOServiceGetMatchingServices(kIOMasterPortDefault, matchingDict, deviceIterator);
+  return IOServiceGetMatchingServices(MACH_PORT_NULL, matchingDict, deviceIterator);
 }
 
 /* Returns 1 on success, 0 on failure. */
@@ -370,7 +370,7 @@ static void darwin_hotplug_poll (void)
   /* since a kernel thread may nodify the IOInterators used for
    * hotplug notidication we can't just clear the iterators.
    * instead just wait until all IOService providers are quiet */
-  (void) IOKitWaitQuiet (kIOMasterPortDefault, &timeout);
+  (void) IOKitWaitQuiet (MACH_PORT_NULL, &timeout);
 }
 
 static void darwin_clear_iterator (io_iterator_t iter) {
@@ -421,7 +421,7 @@ static void *darwin_event_thread_main (void *arg0) {
   CFRunLoopAddSource(runloop, libusb_darwin_acfls, kCFRunLoopDefaultMode);
 
   /* add the notification port to the run loop */
-  libusb_notification_port     = IONotificationPortCreate (kIOMasterPortDefault);
+  libusb_notification_port     = IONotificationPortCreate (MACH_PORT_NULL);
   libusb_notification_cfsource = IONotificationPortGetRunLoopSource (libusb_notification_port);
   CFRunLoopAddSource(runloop, libusb_notification_cfsource, kCFRunLoopDefaultMode);
 
@@ -695,7 +695,7 @@ static int darwin_check_configuration (struct libusb_context *ctx, struct darwin
   } else
     /* not configured */
     dev->active_config = 0;
-  
+
   usbi_dbg ("active config: %u, first config: %u", dev->active_config, dev->first_config);
 
   return 0;


### PR DESCRIPTION
When calling write in Windows, the number of written bytes is off by 1.
This is the result of prepending the HID report ID in Windows. 

This different behavior may result in issues in other layers.  