### PR TITLE
hid: replace wrong sys/poll.h include with poll.h

### DIFF
--- a/hid_enabled.go
+++ b/hid_enabled.go
@@ -19,7 +19,7 @@ package hid
 #cgo windows LDFLAGS: -lsetupapi
 
 #ifdef OS_LINUX
-	#include <sys/poll.h>
+	#include <poll.h>
 	#include "os/threads_posix.c"
 	#include "os/poll_posix.c"
 


### PR DESCRIPTION
Fixes:

#warning redirecting incorrect #include <sys/poll.h> to <poll.h>

Under musl.