### PR TITLE
Export generic usb api for "webUSB device" support

### DIFF
--- a/generic.go
+++ b/generic.go
@@ -32,7 +32,7 @@ type GenericDeviceInfo struct {
 	VendorID  uint16 // Device Vendor ID
 	ProductID uint16 // Device Product ID
 
-	device *C.struct_libusb_device
+	device *GenericDevice
 
 	Interface int
 

--- a/generic.go
+++ b/generic.go
@@ -5,9 +5,7 @@ package hid
 
 import (
 	"C"
-	"sync"
 )
-import "fmt"
 
 type GenericEndpointDirection uint8
 
@@ -34,7 +32,7 @@ type GenericDeviceInfo struct {
 	VendorID  uint16 // Device Vendor ID
 	ProductID uint16 // Device Product ID
 
-	Device GenericLibUsbDevice
+	device *C.struct_libusb_device
 
 	Interface int
 
@@ -53,79 +51,4 @@ func (gdi *GenericDeviceInfo) GetPath() string {
 // IDs returns the vendor and product IDs for the device
 func (gdi *GenericDeviceInfo) IDs() (uint16, uint16, int, uint16) {
 	return gdi.VendorID, gdi.ProductID, gdi.Interface, 0
-}
-
-// Open tries to open the USB device represented by the current DeviceInfo
-func (gdi *GenericDeviceInfo) Open() (Device, error) {
-	device, err := GenericDeviceOpen(gdi.Device)
-	if err != nil {
-		return nil, err
-	}
-
-	newDev := &GenericDevice{
-		GenericDeviceInfo: gdi,
-		device:            device,
-	}
-
-	for _, endpoint := range gdi.Endpoints {
-		switch {
-		case endpoint.Direction == GenericEndpointDirectionOut && endpoint.Attributes == GenericEndpointAttributeInterrupt:
-			newDev.WEndpoint = endpoint.Address
-		case endpoint.Direction == GenericEndpointDirectionIn && endpoint.Attributes == GenericEndpointAttributeInterrupt:
-			newDev.REndpoint = endpoint.Address
-		}
-	}
-
-	if newDev.REndpoint == 0 || newDev.WEndpoint == 0 {
-		return nil, fmt.Errorf("Missing endpoint in device %#x:%#x:%d", gdi.VendorID, gdi.ProductID, gdi.Interface)
-	}
-
-	return newDev, nil
-}
-
-// GenericDevice represents a generic USB device
-type GenericDevice struct {
-	*GenericDeviceInfo // Embed the infos for easier access
-
-	REndpoint uint8
-	WEndpoint uint8
-
-	device GenericDeviceHandle
-	lock   sync.Mutex
-}
-
-// Close a previously opened generic USB device
-func (gd *GenericDevice) Close() error {
-	gd.lock.Lock()
-	defer gd.lock.Unlock()
-
-	if gd.device != nil {
-		GenericDeviceClose(gd.device)
-		gd.device = nil
-	}
-
-	return nil
-}
-
-// Write implements io.ReaderWriter
-func (gd *GenericDevice) Write(b []byte) (int, error) {
-	gd.lock.Lock()
-	defer gd.lock.Unlock()
-
-	out, err := InterruptTransfer(gd.device, gd.WEndpoint, b, 0)
-	return len(out), err
-}
-
-// Read implements io.ReaderWriter
-func (gd *GenericDevice) Read(b []byte) (int, error) {
-	gd.lock.Lock()
-	defer gd.lock.Unlock()
-
-	out, err := InterruptTransfer(gd.device, gd.REndpoint, b, 0)
-	return len(out), err
-}
-
-// Type identify the device as a HID device
-func (gd *GenericDevice) Type() DeviceType {
-	return gd.GenericDeviceInfo.Type()
 }

--- a/generic.go
+++ b/generic.go
@@ -1,0 +1,81 @@
+// hid - Gopher Interface Devices (USB HID)
+// Copyright (c) 2019 Péter Szilágyi, Guillaume Ballet. All rights reserved.
+
+package hid
+
+import (
+	"C"
+	"sync"
+)
+
+type GenericDeviceInfo struct {
+	Path      string // Platform-specific device path
+	VendorID  uint16 // Device Vendor ID
+	ProductID uint16 // Device Product ID
+
+	Device GenericLibUsbDevice
+
+	WEndpoint uint8
+	REndpoint uint8
+}
+
+func (gdi *GenericDeviceInfo) Type() DeviceType {
+	return DeviceTypeGeneric
+}
+
+// Platform-specific device path
+func (gdi *GenericDeviceInfo) GetPath() string {
+	return gdi.Path
+}
+
+// IDs returns the vendor and product IDs for the device
+func (gdi *GenericDeviceInfo) IDs() (uint16, uint16) {
+	return gdi.VendorID, gdi.ProductID
+}
+
+// Open tries to open the USB device represented by the current DeviceInfo
+func (gdi *GenericDeviceInfo) Open() (Device, error) {
+	device, err := GenericDeviceOpen(gdi.Device)
+	if err != nil {
+		return nil, err
+	}
+	return &GenericDevice{
+		GenericDeviceInfo: gdi,
+		device:            device,
+	}, nil
+}
+
+type GenericDevice struct {
+	*GenericDeviceInfo // Embed the infos for easier access
+
+	device GenericDeviceHandle
+	lock   sync.Mutex
+}
+
+func (gd *GenericDevice) Close() error {
+	gd.lock.Lock()
+	defer gd.lock.Unlock()
+
+	if gd.device != nil {
+		GenericDeviceClose(gd.device)
+		gd.device = nil
+	}
+
+	return nil
+}
+
+func (gd *GenericDevice) Write(b []byte) (int, error) {
+	gd.lock.Lock()
+	defer gd.lock.Unlock()
+
+	out, err := InterruptTransfer(gd.device, gd.GenericDeviceInfo.WEndpoint, b, 0)
+	return len(out), err
+}
+
+func (gd *GenericDevice) Read(b []byte) (int, error) {
+	gd.lock.Lock()
+	defer gd.lock.Unlock()
+
+	out, err := InterruptTransfer(gd.device, gd.GenericDeviceInfo.REndpoint, b, 0)
+	return len(out), err
+}

--- a/generic.go
+++ b/generic.go
@@ -48,6 +48,9 @@ func (gdi *GenericDeviceInfo) Open() (Device, error) {
 type GenericDevice struct {
 	*GenericDeviceInfo // Embed the infos for easier access
 
+	WEndpoint uint8
+	REndpoint uint8
+
 	device GenericDeviceHandle
 	lock   sync.Mutex
 }
@@ -68,7 +71,7 @@ func (gd *GenericDevice) Write(b []byte) (int, error) {
 	gd.lock.Lock()
 	defer gd.lock.Unlock()
 
-	out, err := InterruptTransfer(gd.device, gd.GenericDeviceInfo.WEndpoint, b, 0)
+	out, err := InterruptTransfer(gd.device, gd.WEndpoint, b, 0)
 	return len(out), err
 }
 
@@ -76,6 +79,21 @@ func (gd *GenericDevice) Read(b []byte) (int, error) {
 	gd.lock.Lock()
 	defer gd.lock.Unlock()
 
-	out, err := InterruptTransfer(gd.device, gd.GenericDeviceInfo.REndpoint, b, 0)
+	out, err := InterruptTransfer(gd.device, gd.REndpoint, b, 0)
 	return len(out), err
+}
+
+// SetEndpoint sets the endpoint number for either the Read or
+// Write function.
+func (gd *GenericDevice) SetEndpoint(write bool, endpoint uint8) {
+	if write {
+		gd.WEndpoint = endpoint
+	} else {
+		gd.REndpoint = endpoint
+	}
+}
+
+// Type identify the device as a HID device
+func (gd *GenericDevice) Type() DeviceType {
+	return gd.GenericDeviceInfo.Type()
 }

--- a/hid.go
+++ b/hid.go
@@ -17,8 +17,8 @@ var ErrDeviceClosed = errors.New("hid: device closed")
 // operating system is not supported by the library.
 var ErrUnsupportedPlatform = errors.New("hid: unsupported platform")
 
-// DeviceInfo is a hidapi info structure.
-type DeviceInfo struct {
+// HidDeviceInfo is a hidapi info structure.
+type HidDeviceInfo struct {
 	Path         string // Platform-specific device path
 	VendorID     uint16 // Device Vendor ID
 	ProductID    uint16 // Device Product ID
@@ -34,4 +34,19 @@ type DeviceInfo struct {
 	// in all cases, and valid on the Windows implementation
 	// only if the device contains more than one interface.
 	Interface int
+}
+
+// GetPath returns the system-dependent path to the device
+func (hdi *HidDeviceInfo) GetPath() string {
+	return hdi.Path
+}
+
+// IDs returns the vendor and product id of the device
+func (hdi *HidDeviceInfo) IDs() (uint16, uint16) {
+	return hdi.VendorID, hdi.ProductID
+}
+
+// Type returns the type of the device (HID or generic)
+func (hdi *HidDeviceInfo) Type() DeviceType {
+	return DeviceTypeHID
 }

--- a/hid.go
+++ b/hid.go
@@ -42,8 +42,8 @@ func (hdi *HidDeviceInfo) GetPath() string {
 }
 
 // IDs returns the vendor and product id of the device
-func (hdi *HidDeviceInfo) IDs() (uint16, uint16) {
-	return hdi.VendorID, hdi.ProductID
+func (hdi *HidDeviceInfo) IDs() (uint16, uint16, int, uint16) {
+	return hdi.VendorID, hdi.ProductID, hdi.Interface, hdi.UsagePage
 }
 
 // Type returns the type of the device (HID or generic)

--- a/hid_disabled.go
+++ b/hid_disabled.go
@@ -22,30 +22,50 @@ func Enumerate(vendorID uint16, productID uint16) []DeviceInfo {
 	return nil
 }
 
-// Device is a live HID USB connected device handle. On platforms that this file
+// HidDevice is a live HID USB connected device handle. On platforms that this file
 // implements the type lacks the actual HID device and all methods are noop.
-type Device struct {
-	DeviceInfo // Embed the infos for easier access
+type HidDevice struct {
+	HidDeviceInfo // Embed the infos for easier access
 }
 
 // Open connects to an HID device by its path name. On platforms that this file
 // implements the method just returns an error.
-func (info DeviceInfo) Open() (*Device, error) {
+func (info HidDeviceInfo) Open() (*Device, error) {
 	return nil, ErrUnsupportedPlatform
 }
 
 // Close releases the HID USB device handle. On platforms that this file implements
 // the method is just a noop.
-func (dev *Device) Close() error { return nil }
+func (dev *HidDevice) Close() error { return nil }
 
 // Write sends an output report to a HID device. On platforms that this file
 // implements the method just returns an error.
-func (dev *Device) Write(b []byte) (int, error) {
+func (dev *HidDevice) Write(b []byte) (int, error) {
 	return 0, ErrUnsupportedPlatform
 }
 
+// GenericDeviceHandle represents a libusb device_handle struct
+type GenericDeviceHandle *C.struct_libusb_device_handle
+
+// GenericLibUsbDevice represents a libusb device struct
+type GenericLibUsbDevice *C.struct_libusb_device
+
 // Read retrieves an input report from a HID device. On platforms that this file
 // implements the method just returns an error.
-func (dev *Device) Read(b []byte) (int, error) {
+func (dev *HidDevice) Read(b []byte) (int, error) {
 	return 0, ErrUnsupportedPlatform
+}
+
+// GenericDeviceOpen is a helper function to call the C version of open.
+func GenericDeviceOpen(dev GenericLibUsbDevice) (GenericDeviceHandle, error) {
+	return nil, ErrUnsupportedPlatform
+}
+
+// GenericDeviceClose is a helper function to close a libusb device
+func GenericDeviceClose(handle GenericDeviceHandle) {
+}
+
+// InterruptTransfer is a helpler function for libusb's interrupt transfer function
+func InterruptTransfer(handle GenericDeviceHandle, endpoint uint8, data []byte, timeout uint) ([]byte, error) {
+	return data[:0], ErrUnsupportedPlatform
 }

--- a/hid_disabled.go
+++ b/hid_disabled.go
@@ -36,7 +36,7 @@ func (info HidDeviceInfo) Open() (*Device, error) {
 
 // Close releases the HID USB device handle. On platforms that this file implements
 // the method is just a noop.
-func (dev *HidDevice) Close() error { return nil }
+func (dev *HidDevice) Close() error { return ErrUnsupportedPlatform }
 
 // Write sends an output report to a HID device. On platforms that this file
 // implements the method just returns an error.
@@ -44,28 +44,33 @@ func (dev *HidDevice) Write(b []byte) (int, error) {
 	return 0, ErrUnsupportedPlatform
 }
 
-// GenericDeviceHandle represents a libusb device_handle struct
-type GenericDeviceHandle interface{}
-
-// GenericLibUsbDevice represents a libusb device struct
-type GenericLibUsbDevice interface{}
-
 // Read retrieves an input report from a HID device. On platforms that this file
 // implements the method just returns an error.
 func (dev *HidDevice) Read(b []byte) (int, error) {
 	return 0, ErrUnsupportedPlatform
 }
 
-// GenericDeviceOpen is a helper function to call the C version of open.
-func GenericDeviceOpen(dev GenericLibUsbDevice) (GenericDeviceHandle, error) {
+// Open tries to open the USB device represented by the current DeviceInfo
+func (gdi *GenericDeviceInfo) Open() (Device, error) {
 	return nil, ErrUnsupportedPlatform
 }
 
-// GenericDeviceClose is a helper function to close a libusb device
-func GenericDeviceClose(handle GenericDeviceHandle) {
+// GenericDevice represents a generic USB device
+type GenericDevice struct {
+	*GenericDeviceInfo // Embed the infos for easier access
 }
 
-// InterruptTransfer is a helpler function for libusb's interrupt transfer function
-func InterruptTransfer(handle GenericDeviceHandle, endpoint uint8, data []byte, timeout uint) ([]byte, error) {
-	return data[:0], ErrUnsupportedPlatform
+// Write implements io.ReaderWriter
+func (gd *GenericDevice) Write(b []byte) (int, error) {
+	return 0, ErrUnsupportedPlatform
+}
+
+// Read implements io.ReaderWriter
+func (gd *GenericDevice) Read(b []byte) (int, error) {
+	return 0, ErrUnsupportedPlatform
+}
+
+// Close a previously opened generic USB device
+func (gd *GenericDevice) Close() error {
+	return ErrUnsupportedPlatform
 }

--- a/hid_disabled.go
+++ b/hid_disabled.go
@@ -45,10 +45,10 @@ func (dev *HidDevice) Write(b []byte) (int, error) {
 }
 
 // GenericDeviceHandle represents a libusb device_handle struct
-type GenericDeviceHandle *C.struct_libusb_device_handle
+type GenericDeviceHandle interface{}
 
 // GenericLibUsbDevice represents a libusb device struct
-type GenericLibUsbDevice *C.struct_libusb_device
+type GenericLibUsbDevice interface{}
 
 // Read retrieves an input report from a HID device. On platforms that this file
 // implements the method just returns an error.

--- a/hid_disabled.go
+++ b/hid_disabled.go
@@ -4,7 +4,7 @@
 // This file is released under the 3-clause BSD license. Note however that Linux
 // support depends on libusb, released under GNU LGPL 2.1 or later.
 
-// +build !linux,!darwin,!windows ios !cgo
+// +build !freebsd,!linux,!darwin,!windows ios !cgo
 
 package hid
 

--- a/hid_enabled.go
+++ b/hid_enabled.go
@@ -48,8 +48,9 @@ package hid
 #if defined(OS_LINUX) || defined(OS_WINDOWS)
 	void copy_device_list_to_slice(struct libusb_device **data, struct libusb_device **list, int count)
 	{
+		int i;
 		struct libusb_device *current = *list;
-		for (int i=0; i<count; i++)
+		for (i=0; i<count; i++)
 		{
 			 data[i] = current;
 			 current = list_entry(current->list.next, struct libusb_device, list);
@@ -58,13 +59,19 @@ package hid
 #elif defined(OS_DARWIN) || defined(__FreeBSD__)
 	void copy_device_list_to_slice(struct libusb_device **data, struct libusb_device **list, int count)
 	{
+		int i;
 		// No memcopy because the struct size isn't available for a sizeof()
-		for (int i=0; i<count; i++)
+		for (i=0; i<count; i++)
 		{
 			data[i] = list[i];
 		}
 	}
 #endif
+
+const char *usb_strerror(int err)
+{
+	return libusb_strerror(err);
+}
 */
 import "C"
 
@@ -382,7 +389,7 @@ func InterruptTransfer(handle GenericDeviceHandle, endpoint uint8, data []byte, 
 	var transferred C.int
 	errCode := int(C.libusb_interrupt_transfer(handle, (C.uchar)(endpoint), (*C.uchar)(&data[0]), (C.int)(len(data)), &transferred, (C.uint)(timeout)))
 	if errCode != 0 {
-		return nil, fmt.Errorf("Interrupt transfer error: %s", C.libusb_strerror(errCode))
+		return nil, fmt.Errorf("Interrupt transfer error: %s", C.usb_strerror(C.int(errCode)))
 	}
 	return data[:int(transferred)], nil
 }

--- a/hid_enabled.go
+++ b/hid_enabled.go
@@ -83,7 +83,6 @@ import (
 	"reflect"
 	"runtime"
 	"sync"
-	"time"
 	"unsafe"
 )
 
@@ -418,7 +417,7 @@ func (gd *GenericDevice) Write(b []byte) (int, error) {
 	gd.lock.Lock()
 	defer gd.lock.Unlock()
 
-	out, err := interruptTransfer(gd.device, gd.WEndpoint, b, 0)
+	out, err := interruptTransfer(gd.device, gd.WEndpoint, b)
 	return len(out), err
 }
 
@@ -427,7 +426,7 @@ func (gd *GenericDevice) Read(b []byte) (int, error) {
 	gd.lock.Lock()
 	defer gd.lock.Unlock()
 
-	out, err := interruptTransfer(gd.device, gd.REndpoint, b, 0)
+	out, err := interruptTransfer(gd.device, gd.REndpoint, b)
 	return len(out), err
 }
 
@@ -445,9 +444,9 @@ func (gd *GenericDevice) Close() error {
 }
 
 // interruptTransfer is a helpler function for libusb's interrupt transfer function
-func interruptTransfer(handle *C.struct_libusb_device_handle, endpoint uint8, data []byte, timeout uint) ([]byte, error) {
+func interruptTransfer(handle *C.struct_libusb_device_handle, endpoint uint8, data []byte) ([]byte, error) {
 	var transferred C.int
-	errCode := int(C.libusb_interrupt_transfer(handle, (C.uchar)(endpoint), (*C.uchar)(&data[0]), (C.int)(len(data)), &transferred, (C.uint)(timeout)))
+	errCode := int(C.libusb_interrupt_transfer(handle, (C.uchar)(endpoint), (*C.uchar)(&data[0]), (C.int)(len(data)), &transferred, (C.uint)(0)))
 	if errCode != 0 {
 		return nil, fmt.Errorf("Interrupt transfer error: %s", C.GoString(C.usb_strerror(C.int(errCode))))
 	}

--- a/hid_enabled.go
+++ b/hid_enabled.go
@@ -382,7 +382,7 @@ func InterruptTransfer(handle GenericDeviceHandle, endpoint uint8, data []byte, 
 	var transferred C.int
 	errCode := int(C.libusb_interrupt_transfer(handle, (C.uchar)(endpoint), (*C.uchar)(&data[0]), (C.int)(len(data)), &transferred, (C.uint)(timeout)))
 	if errCode != 0 {
-		return nil, fmt.Errorf("Interrupt transfer error, code %d", errCode)
+		return nil, fmt.Errorf("Interrupt transfer error: %s", C.libusb_strerror(errCode))
 	}
 	return data[:int(transferred)], nil
 }

--- a/usb.go
+++ b/usb.go
@@ -32,8 +32,9 @@ type DeviceInfo interface {
 	// Platform-specific device path
 	GetPath() string
 
-	// IDs returns the vendor and product IDs for the device
-	IDs() (uint16, uint16)
+	// IDs returns the vendor and product IDs for the device,
+	// as well as the endpoint id and the usage page.
+	IDs() (uint16, uint16, int, uint16)
 
 	// Open tries to open the USB device represented by the current DeviceInfo
 	Open() (Device, error)

--- a/usb.go
+++ b/usb.go
@@ -1,0 +1,47 @@
+// hid - Gopher Interface Devices (USB HID)
+// Copyright (c) 2019 Péter Szilágyi, Guillaume Ballet. All rights reserved.
+//
+// This file is released under the 3-clause BSD license. Note however that Linux
+// support depends on libusb, released under GNU LGPL 2.1 or later.
+
+// Package usb provide interfaces for generic USB devices.
+package hid
+
+// DeviceType represents the type of a USB device (generic or HID)
+type DeviceType int
+
+const (
+	DeviceTypeGeneric DeviceType = 0
+	DeviceTypeHID     DeviceType = 0
+)
+
+// Enumerate returns a list of all the HID devices attached to the system which
+// match the vendor and product id:
+//  - If the vendor id is set to 0 then any vendor matches.
+//  - If the product id is set to 0 then any product matches.
+//  - If the vendor and product id are both 0, all HID devices are returned.
+// func Enumerate(vendorID uint16, productID uint16) []DeviceInfo {
+// }
+
+// DeviceInfo is a generic libusb info interface
+type DeviceInfo interface {
+	Type() DeviceType
+
+	// Platform-specific device path
+	GetPath() string
+
+	// IDs returns the vendor and product IDs for the device
+	IDs() (uint16, uint16)
+
+	// Open tries to open the USB device represented by the current DeviceInfo
+	Open() (Device, error)
+}
+
+// DeviceInfo is a generic libusb device interface
+type Device interface {
+	Close() error
+
+	Write(b []byte) (int, error)
+
+	Read(b []byte) (int, error)
+}

--- a/usb.go
+++ b/usb.go
@@ -10,9 +10,10 @@ package hid
 // DeviceType represents the type of a USB device (generic or HID)
 type DeviceType int
 
+// List of supported device types
 const (
 	DeviceTypeGeneric DeviceType = 0
-	DeviceTypeHID     DeviceType = 0
+	DeviceTypeHID     DeviceType = 1
 )
 
 // Enumerate returns a list of all the HID devices attached to the system which
@@ -25,6 +26,7 @@ const (
 
 // DeviceInfo is a generic libusb info interface
 type DeviceInfo interface {
+	// Type returns the type of the device (generic or HID)
 	Type() DeviceType
 
 	// Platform-specific device path
@@ -37,11 +39,14 @@ type DeviceInfo interface {
 	Open() (Device, error)
 }
 
-// DeviceInfo is a generic libusb device interface
+// Device is a generic libusb device interface
 type Device interface {
 	Close() error
 
 	Write(b []byte) (int, error)
 
 	Read(b []byte) (int, error)
+
+	// Type returns the type of the device (generic or HID)
+	Type() DeviceType
 }

--- a/wchar.go
+++ b/wchar.go
@@ -7,7 +7,7 @@
 // https://github.com/orofarne/gowchar/blob/master/LICENSE
 
 // +build !ios
-// +build linux darwin windows
+// +build freebsd linux darwin windows
 
 package hid
 


### PR DESCRIPTION
This PR extends the current API to also let client code handle non-hid ("generic") USB devices. This is done by offering two types of devices behind a `Device` interface: `HidDevice` (formerly `Device`) and `GenericDevice`.

Most of the work happens in `Enumerate` : the function starts by enumerating generic devices and skipping those who are going to be picked up by the HID code. Doing it the other way around has advantages, I'm considering switching.

libusb hasn't been updated in this version, as it uses the same interface as the latest version. I'm happy to upgrade it in a subsequent PR.

*TODO* The last issue that I'm aware of, is to ensure that it builds and works on ~~macos and~~ Windows