### PR TITLE
travis.yml: use Ubuntu Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,10 @@ matrix:
       dist: trusty
       go: 1.9.x
     - os: linux
-      dist: precise
+      dist: xenial
       go: 1.9.x
     - os: linux
-      dist: precise
+      dist: xenial
       go: 1.10.x
     - os: osx
       go: 1.10.x


### PR DESCRIPTION
I am getting a warning that the 10.x builds rely on Ubuntu Precise, which is going to be decommissioned by Travis. Upgrade to Xenial.