### PR TITLE
Fix go mod vendor

### DIFF
--- a/hid_enabled.go
+++ b/hid_enabled.go
@@ -47,6 +47,14 @@ import (
 	"runtime"
 	"sync"
 	"unsafe"
+
+	// go mod vendor prunes non-go dirs https://github.com/golang/go/issues/26366
+	_ "github.com/karalabe/hid/libusb/libusb"
+	_ "github.com/karalabe/hid/libusb/libusb/os"
+	_ "github.com/karalabe/hid/hidapi/hidapi"
+	_ "github.com/karalabe/hid/hidapi/libusb"
+	_ "github.com/karalabe/hid/hidapi/mac"
+	_ "github.com/karalabe/hid/hidapi/windows"
 )
 
 // enumerateLock is a mutex serializing access to USB device enumeration needed

--- a/hidapi/hidapi/dummy.go
+++ b/hidapi/hidapi/dummy.go
@@ -1,2 +1,3 @@
 // go mod vendor prunes non-go dirs https://github.com/golang/go/issues/26366
+
 package hidapi_hidapi

--- a/hidapi/hidapi/dummy.go
+++ b/hidapi/hidapi/dummy.go
@@ -1,0 +1,2 @@
+// go mod vendor prunes non-go dirs https://github.com/golang/go/issues/26366
+package hidapi_hidapi

--- a/hidapi/libusb/dummy.go
+++ b/hidapi/libusb/dummy.go
@@ -1,0 +1,2 @@
+// go mod vendor prunes non-go dirs https://github.com/golang/go/issues/26366
+package hidapi_libusb

--- a/hidapi/libusb/dummy.go
+++ b/hidapi/libusb/dummy.go
@@ -1,2 +1,3 @@
 // go mod vendor prunes non-go dirs https://github.com/golang/go/issues/26366
+
 package hidapi_libusb

--- a/hidapi/mac/dummy.go
+++ b/hidapi/mac/dummy.go
@@ -1,2 +1,3 @@
 // go mod vendor prunes non-go dirs https://github.com/golang/go/issues/26366
+
 package hidapi_mac

--- a/hidapi/mac/dummy.go
+++ b/hidapi/mac/dummy.go
@@ -1,0 +1,2 @@
+// go mod vendor prunes non-go dirs https://github.com/golang/go/issues/26366
+package hidapi_mac

--- a/hidapi/windows/dummy.go
+++ b/hidapi/windows/dummy.go
@@ -1,2 +1,3 @@
 // go mod vendor prunes non-go dirs https://github.com/golang/go/issues/26366
+
 package hidapi_windows

--- a/hidapi/windows/dummy.go
+++ b/hidapi/windows/dummy.go
@@ -1,0 +1,2 @@
+// go mod vendor prunes non-go dirs https://github.com/golang/go/issues/26366
+package hidapi_windows

--- a/libusb/libusb/dummy.go
+++ b/libusb/libusb/dummy.go
@@ -1,0 +1,2 @@
+// go mod vendor prunes non-go dirs https://github.com/golang/go/issues/26366
+package libusb

--- a/libusb/libusb/dummy.go
+++ b/libusb/libusb/dummy.go
@@ -1,2 +1,3 @@
 // go mod vendor prunes non-go dirs https://github.com/golang/go/issues/26366
+
 package libusb

--- a/libusb/libusb/os/dummy.go
+++ b/libusb/libusb/os/dummy.go
@@ -1,2 +1,3 @@
 // go mod vendor prunes non-go dirs https://github.com/golang/go/issues/26366
+
 package libusb_os

--- a/libusb/libusb/os/dummy.go
+++ b/libusb/libusb/os/dummy.go
@@ -1,0 +1,2 @@
+// go mod vendor prunes non-go dirs https://github.com/golang/go/issues/26366
+package libusb_os


### PR DESCRIPTION
This works around https://github.com/golang/go/issues/26366 by adding a `dummy.go` file in required folders. Without this fix, all C and H files will be missing from the vendor folder, causing the build to fail.

For another example, see https://github.com/Hywan/go-ext-wasm/commit/4724910709abd61d86be29dac079c85f660c3595
