### PR TITLE
Add libusb upgrade script

### DIFF
--- a/upgrade-libusb.sh
+++ b/upgrade-libusb.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+	echo "usage: $0 <version>"
+	echo "See https://github.com/libusb/libusb/releases"
+	exit 1
+fi
+version="$1"
+if [[ "$version" = v* ]]; then
+	version="${version#v}"
+fi
+
+archive=libusb-${version}.tar.bz2
+
+curl -L -o "$archive" "https://github.com/libusb/libusb/releases/download/v$version/$archive"
+
+rm -Rf libusb-${version}
+tar xjf "$archive"
+
+rm -Rf libusb.orig
+if [[ -d libusb ]]; then
+	mv libusb libusb.orig
+fi
+mv libusb-${version} libusb
+rm -Rf libusb.orig "$archive"

--- a/upgrade-libusb.sh
+++ b/upgrade-libusb.sh
@@ -2,12 +2,15 @@
 
 set -euo pipefail
 
-if [[ -z "${1:-}" ]]; then
-	echo "usage: $0 <version>"
-	echo "See https://github.com/libusb/libusb/releases"
-	exit 1
+version="${1:-}"
+if [[ -z "$version" ]]; then
+	# jq -r '.[0].tag_name'
+	version="$(curl -s -H 'Accept: application/vnd.github.v3+json' \
+			'https://api.github.com/repos/libusb/libusb/releases?per_page=1' \
+			| sed -n 's/ *"tag_name": *"v\([^"]*\)",$/\1/p'
+	)"
 fi
-version="$1"
+
 if [[ "$version" = v* ]]; then
 	version="${version#v}"
 fi


### PR DESCRIPTION
Add a script that downloads and install a given version of `libusb`. This will allow to upgrade the bundled `libusb`.

Usage:   `./upgrade-libusb.sh <version>`
Example: `./upgrade-lubusb.sh 1.0.24`