### PR TITLE
Add hidapi upgrade script

### DIFF
--- a/upgrade-hidapi.sh
+++ b/upgrade-hidapi.sh
@@ -2,14 +2,18 @@
 
 set -euo pipefail
 
-if [[ -z "${1:-}" ]]; then
-	echo "usage: $0 <version>"
-	echo "See https://github.com/libusb/hidapi/releases"
-	exit 1
+version="${1:-}"
+if [[ -z "$version" ]]; then
+	# jq -r '.[0].tag_name'
+	version="$(curl -s -H 'Accept: application/vnd.github.v3+json' \
+		'https://api.github.com/repos/libusb/hidapi/releases?per_page=1' \
+		| sed -n 's/ *"tag_name": *"hidapi-\([^"]*\)",$/\1/p'
+	)"
+	echo "$version" && exit 1
 fi
-version="$1"
-if [[ "$version" = v* ]]; then
-	version="${version#v}"
+
+if [[ "$version" = hidapi-* ]]; then
+	version="${version#hidapi-}"
 fi
 
 archive=hidapi-${version}.zip

--- a/upgrade-hidapi.sh
+++ b/upgrade-hidapi.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+	echo "usage: $0 <version>"
+	echo "See https://github.com/libusb/hidapi/releases"
+	exit 1
+fi
+version="$1"
+if [[ "$version" = v* ]]; then
+	version="${version#v}"
+fi
+
+archive=hidapi-${version}.zip
+dir=hidapi-hidapi-${version}
+
+curl -L -o "$archive" "https://github.com/libusb/hidapi/archive/refs/tags/$archive"
+
+rm -Rf $dir
+unzip "$archive"
+
+rm -Rf hidapi.orig
+if [[ -d hidapi ]]; then
+	mv hidapi hidapi.orig
+fi
+mv $dir hidapi
+rm -Rf hidapi.orig "$archive"


### PR DESCRIPTION
Add a script that downloads and install a given version of hidapi. This will allow to upgrade the bundled hidapi.

Usage:   `./upgrade-hidapi.sh <version>`
Example: `./upgrade-hidapi.sh 0.11.2`