### PR TITLE
Revert "Fix for incorrect reported written bytes on Windows"

### DIFF
--- a/hid_enabled.go
+++ b/hid_enabled.go
@@ -182,10 +182,8 @@ func (dev *hidDevice) Write(b []byte) (int, error) {
 	}
 	// Prepend a HID report ID on Windows, other OSes don't need it
 	var report []byte
-	fixlen := 0
 	if runtime.GOOS == "windows" {
 		report = append([]byte{0x00}, b...)
-		fixlen = -1
 	} else {
 		report = b
 	}
@@ -207,9 +205,6 @@ func (dev *hidDevice) Write(b []byte) (int, error) {
 		}
 		failure, _ := wcharTToString(message)
 		return 0, errors.New("hidapi: " + failure)
-	}
-	if written > 0 {
-		written += fixlen
 	}
 	return written, nil
 }


### PR DESCRIPTION
Reverts karalabe/hid#38

----------

This issue was, as far as I can tell, fixed upstream, 
Discussion: https://github.com/libusb/hidapi/issues/229 
Fix: https://github.com/libusb/hidapi/pull/232 

N.B. : I don't have a windows-machine