### PR TITLE
hid read: use -1 to denote blocking read

### DIFF
--- a/hid_enabled.go
+++ b/hid_enabled.go
@@ -216,10 +216,10 @@ func (dev *hidDevice) Write(b []byte) (int, error) {
 
 // Read retrieves an input report from a HID device, blocking and waiting for a response
 func (dev *hidDevice) Read(b []byte) (int, error) {
-	return dev.ReadTimeout(b, 0)
+	return dev.ReadTimeout(b, -1)
 }
 
-// ReadTimeout retrieves an input report from a HID device with a timeout. If timeout is 0 a
+// ReadTimeout retrieves an input report from a HID device with a timeout. If timeout is -1, a
 // blocking read is performed.
 func (dev *hidDevice) ReadTimeout(b []byte, timeout int) (int, error) {
 	// Abort if nothing to read


### PR DESCRIPTION
Fixes an error from #22:

See https://github.com/libusb/hidapi/blob/master/hidapi/hidapi.h#L339

```c
		/** @brief Read an Input report from a HID device with timeout.

			Input reports are returned
			to the host through the INTERRUPT IN endpoint. The first byte will
			contain the Report number if the device uses numbered reports.

			@ingroup API
			@param dev A device handle returned from hid_open().
			@param data A buffer to put the read data into.
			@param length The number of bytes to read. For devices with
				multiple reports, make sure to read an extra byte for
				the report number.
			@param milliseconds timeout in milliseconds or -1 for blocking wait.

			@returns
				This function returns the actual number of bytes read and
				-1 on error.
				Call hid_error(dev) to get the failure reason.
				If no packet was available to be read within
				the timeout period, this function returns 0.
		*/
		int HID_API_EXPORT HID_API_CALL hid_read_timeout(hid_device *dev, unsigned char *data, size_t length, int milliseconds);
```