### PR TITLE
hid_enabled: fix a build-error on docker / alpine

### DIFF
--- a/Dockerfile.libc
+++ b/Dockerfile.libc
@@ -1,0 +1,12 @@
+# This dockerfile exists in order to verify that building
+# 'hid' within libc-based docker setups is possible. It is 
+# not a 'production' dockerfile, just for to aid QA.
+
+FROM golang:latest
+
+RUN apt-get install gcc
+
+ADD . $GOPATH/src/github.com/karalabe/hid
+RUN cd $GOPATH/src/github.com/karalabe/hid && go build demo.go && mv demo /demo
+
+ENTRYPOINT ["/demo"]

--- a/Dockerfile.musl
+++ b/Dockerfile.musl
@@ -1,0 +1,12 @@
+# This dockerfile exists in order to verify that building
+# 'hid' within musl-based docker setups is possible. It is 
+# not a 'production' dockerfile, just for to aid QA.
+
+FROM golang:alpine
+
+RUN apk add --no-cache gcc musl-dev linux-headers
+
+ADD . $GOPATH/src/github.com/karalabe/hid
+RUN cd $GOPATH/src/github.com/karalabe/hid && go build demo.go && mv demo /demo
+
+ENTRYPOINT ["/demo"]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ clone_depth: 1
 version: "{branch}.{build}"
 
 image:
-  - Ubuntu
+  - Ubuntu2204
   - Visual Studio 2019
 
 environment:
@@ -19,7 +19,7 @@ install:
 for:
   - matrix:
       only:
-        - image: Ubuntu
+        - image: Ubuntu2204
     build_script:
       - gcc --version
       - go build ./...

--- a/hid_enabled.go
+++ b/hid_enabled.go
@@ -22,7 +22,7 @@ specifically for the linux platform, below.
 #cgo CFLAGS: -DPOLL_NFDS_TYPE=int
 
 #cgo linux CFLAGS: -I./libusb/libusb -DOS_LINUX -D_GNU_SOURCE -DHAVE_SYS_TIME_H -DHAVE_CLOCK_GETTIME
-#cgo linux,!android LDFLAGS: -lrt -lpthreads
+#cgo linux,!android LDFLAGS: -lrt
 
 #cgo darwin CFLAGS: -DOS_DARWIN -DHAVE_SYS_TIME_H
 #cgo darwin LDFLAGS: -framework CoreFoundation -framework IOKit -lobjc

--- a/hid_enabled.go
+++ b/hid_enabled.go
@@ -22,7 +22,7 @@ specifically for the linux platform, below.
 #cgo CFLAGS: -DPOLL_NFDS_TYPE=int
 
 #cgo linux CFLAGS: -I./libusb/libusb -DOS_LINUX -D_GNU_SOURCE -DHAVE_SYS_TIME_H -DHAVE_CLOCK_GETTIME
-#cgo linux,!android LDFLAGS: -lrt
+#cgo linux,!android LDFLAGS: -lrt -lpthreads
 
 #cgo darwin CFLAGS: -DOS_DARWIN -DHAVE_SYS_TIME_H
 #cgo darwin LDFLAGS: -framework CoreFoundation -framework IOKit -lobjc
@@ -44,7 +44,6 @@ specifically for the linux platform, below.
 	#include "os/threads_posix.h"
 
 	#include "os/events_posix.c"
-	#include "os/threads_posix.c"
 
 	#include "os/linux_usbfs.c"
 	#include "os/linux_netlink.c"

--- a/hid_enabled.go
+++ b/hid_enabled.go
@@ -44,6 +44,7 @@ specifically for the linux platform, below.
 	#include "os/threads_posix.h"
 
 	#include "os/events_posix.c"
+	#include "os/threads_posix.c"
 
 	#include "os/linux_usbfs.c"
 	#include "os/linux_netlink.c"

--- a/libusb/libusb/os/threads_posix.h
+++ b/libusb/libusb/os/threads_posix.h
@@ -64,8 +64,11 @@ static inline void usbi_cond_wait(usbi_cond_t *cond, usbi_mutex_t *mutex)
 {
 	PTHREAD_CHECK(pthread_cond_wait(cond, mutex));
 }
-int usbi_cond_timedwait(usbi_cond_t *cond,
-	usbi_mutex_t *mutex, const struct timeval *tv);
+// This has been commented out, to avoid conflicting alpine/musl from complaining
+// about conflicting types. It is defined and implemented in threads_posix.c instead.
+//int usbi_cond_timedwait(usbi_cond_t *cond,
+//	usbi_mutex_t *mutex, const struct timeval *tv);
+
 static inline void usbi_cond_broadcast(usbi_cond_t *cond)
 {
 	PTHREAD_CHECK(pthread_cond_broadcast(cond));


### PR DESCRIPTION
This PR fixes an error on docker/alpine builds. 

Error: 

```
7.675 In file included from ./hid_enabled.go:47:                                                                                                                                                                            
7.675 ./libusb/libusb/os/threads_posix.c:54:5: error: conflicting types for 'usbi_cond_timedwait'; have 'int(pthread_cond_t *, pthread_mutex_t *, const struct timeval *)'                                                  
7.675    54 | int usbi_cond_timedwait(pthread_cond_t *cond,                                                                                                                                                                 
7.675       |     ^~~~~~~~~~~~~~~~~~~
7.675 In file included from ./hid_enabled.go:44:
7.675 ./libusb/libusb/os/threads_posix.h:67:5: note: previous declaration of 'usbi_cond_timedwait' with type 'int(usbi_cond_t *, usbi_mutex_t *, const struct timeval *)' {aka 'int(pthread_cond_t *, pthread_mutex_t *, const struct timeval *)'}
7.675    67 | int usbi_cond_timedwait(usbi_cond_t *cond,

```

This PR also adds two docker-files, which can be used to verify that both gcc and musl can build it. 
```
$ docker build . -f ./Dockerfile.libc -t test && docker run test
...
hid.Supported() true
...
$ docker build . -f ./Dockerfile.musl -t test && docker run test
...
hid.Supported() true
```